### PR TITLE
Add simple client database application

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# tesrt
+# Client Database Application
+
+This repository provides a small Python application for managing a database of clients using SQLite.
+
+## Usage
+
+Initialize the database and add a new client:
+
+```bash
+python client_db.py add "Alice" alice@example.com
+```
+
+List existing clients:
+
+```bash
+python client_db.py list
+```
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+pytest
+```

--- a/client_db.py
+++ b/client_db.py
@@ -1,0 +1,59 @@
+import sqlite3
+from typing import List, Tuple
+
+DB_NAME = "clients.db"
+
+def init_db(db_name: str = DB_NAME) -> None:
+    """Initialize the database and create the clients table if it doesn't exist."""
+    with sqlite3.connect(db_name) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS clients (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                email TEXT NOT NULL
+            )
+            """
+        )
+
+
+def add_client(name: str, email: str, db_name: str = DB_NAME) -> None:
+    """Add a client to the database."""
+    with sqlite3.connect(db_name) as conn:
+        conn.execute(
+            "INSERT INTO clients (name, email) VALUES (?, ?)", (name, email)
+        )
+
+
+def list_clients(db_name: str = DB_NAME) -> List[Tuple[int, str, str]]:
+    """Return a list of all clients as (id, name, email) tuples."""
+    with sqlite3.connect(db_name) as conn:
+        cursor = conn.execute(
+            "SELECT id, name, email FROM clients ORDER BY id"
+        )
+        return list(cursor.fetchall())
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Client database application")
+    subparsers = parser.add_subparsers(dest="command")
+
+    add_parser = subparsers.add_parser("add", help="Add a new client")
+    add_parser.add_argument("name", help="Name of the client")
+    add_parser.add_argument("email", help="Email of the client")
+
+    subparsers.add_parser("list", help="List all clients")
+
+    args = parser.parse_args()
+    init_db()
+
+    if args.command == "add":
+        add_client(args.name, args.email)
+        print("Client added.")
+    elif args.command == "list":
+        for client in list_clients():
+            print(f"{client[0]}: {client[1]} <{client[2]}>")
+    else:
+        parser.print_help()

--- a/tests/test_client_db.py
+++ b/tests/test_client_db.py
@@ -1,0 +1,20 @@
+import os
+import tempfile
+
+from client_db import init_db, add_client, list_clients
+
+
+def test_add_and_list_clients():
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        db_path = tmp.name
+    try:
+        init_db(db_path)
+        add_client("Alice", "alice@example.com", db_path)
+        add_client("Bob", "bob@example.com", db_path)
+        clients = list_clients(db_path)
+        assert clients == [
+            (1, "Alice", "alice@example.com"),
+            (2, "Bob", "bob@example.com"),
+        ]
+    finally:
+        os.remove(db_path)


### PR DESCRIPTION
## Summary
- implement SQLite-backed client database module with command-line interface
- document usage and testing instructions in README
- add unit test verifying adding and listing clients

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ec841a9d48325baf3c8da8f6bf51a